### PR TITLE
python 3.8 workaround: bytes has no encode

### DIFF
--- a/spotify_ripper/utils.py
+++ b/spotify_ripper/utils.py
@@ -26,7 +26,10 @@ def get_args():
 
 def enc_str(_str):
     encoding = "ascii" if get_args().ascii else "utf-8"
-    return _str.encode(encoding)
+    if type(_str) == bytes:
+      return _str
+    else:
+      return _str.encode(encoding)
 
 
 def path_exists(path):


### PR DESCRIPTION
Exception in thread SpotifyRipperThread:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.8/dist-packages/spotify_ripper/ripper.py", line 334, in run
    self.post.end_failure_log()   
  File "/usr/local/lib/python3.8/dist-packages/spotify_ripper/post_actions.py", line 48, in end_failure_log
    if os.path.getsize(enc_str(file_name)) == 0:
  File "/usr/local/lib/python3.8/dist-packages/spotify_ripper/utils.py", line 29, in enc_str
    return _str.encode(encoding)  
AttributeError: 'bytes' object has no attribute 'encode'
Segmentation fault (core dumped)